### PR TITLE
Update tc-admin to 2.3.0

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -37,7 +37,7 @@ tasks:
       workerType: ci
       payload:
         maxRunTime: 1200
-        image: python:3.7-slim
+        image: python:3.7
         command:
           - /bin/bash
           - -cxe

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -62,7 +62,7 @@ tasks:
       workerType: ci
       payload:
         maxRunTime: 1200
-        image: python:3.7-slim
+        image: python:3.7
         command:
           - /bin/bash
           - -cxe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7
 
 COPY . /src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,24 @@
-FROM python:3.7
+FROM python:3.7 AS builder
+
+COPY . /src
+RUN pip wheel --wheel-dir=/root/wheels -r /src/requirements.txt
+
+FROM python:3.7-slim
 
 COPY . /src
 
 # Setup git for ssh clones
-RUN apt-get update -qq && apt-get install -qq git openssh-client
-RUN mkdir ~/.ssh && chmod 0600 ~/.ssh && ssh-keyscan github.com > ~/.ssh/known_hosts
+RUN apt-get update -qq \
+    && apt-get install -qq --no-install-recommends git openssh-client \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --disable-pip-version-check --no-cache-dir --quiet /src
+RUN mkdir ~/.ssh \
+    && chmod 0600 ~/.ssh \
+    && ssh-keyscan github.com > ~/.ssh/known_hosts
+
+COPY --from=builder /root/wheels /root/wheels
+RUN pip install --disable-pip-version-check --no-cache-dir --find-links=/root/wheels --quiet /src \
+    && rm -rf /root/wheels
 
 # Setup env variable for tc-admin.py discovery
 ENV TC_ADMIN_PY=/src/tc-admin.py

--- a/decision/__init__.py
+++ b/decision/__init__.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 import logging
 
+from taskcluster.helper import TaskclusterConfig
+
 # Setup logger
 logging.basicConfig(level=logging.INFO)
+
+# Shared taskcluster configuration
+taskcluster = TaskclusterConfig("https://community-tc.services.mozilla.com")
+taskcluster.auth()
 
 # Constants for our resources
 OWNER_EMAIL = "fuzzing+taskcluster@mozilla.com"

--- a/decision/workflow.py
+++ b/decision/workflow.py
@@ -8,12 +8,11 @@ import subprocess
 import tempfile
 
 import yaml
-from taskcluster import Secrets
-from taskcluster import optionsFromEnvironment
 from tcadmin.appconfig import AppConfig
 
 from decision import HOOK_PREFIX
 from decision import WORKER_POOL_PREFIX
+from decision import taskcluster
 from decision.pool import MachineTypes
 from decision.pool import PoolConfiguration
 from decision.providers import AWS
@@ -66,14 +65,7 @@ class Workflow(object):
             config = yaml.safe_load(open(local_path))
 
         elif secret is not None:
-            # Use Proxy when available
-            tc_options = optionsFromEnvironment()
-            if "TASKCLUSTER_PROXY_URL" in os.environ:
-                tc_options["rootUrl"] = os.environ["TASKCLUSTER_PROXY_URL"]
-            secrets = Secrets(tc_options)
-            response = secrets.get(secret)
-            assert response is not None, "Invalid Taskcluster secret payload"
-            config = response["secret"]
+            config = taskcluster.load_secrets(secret)
         else:
             raise Exception("Specify local_path XOR secret")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-pyyaml==5.2
-tc-admin==2.2.0
+tc-admin==2.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 import responses
 
+from decision import taskcluster
 from decision.pool import MachineTypes
 from decision.providers import AWS
 from decision.providers import GCP
@@ -19,7 +20,7 @@ def mock_taskcluster():
     """Mock Taskcluster HTTP services"""
 
     # Setup mock url for taskcluster services
-    os.environ["TASKCLUSTER_ROOT_URL"] = "http://taskcluster.test"
+    taskcluster.options = {"rootUrl": "http://taskcluster.test"}
 
     # Add a basic configuration for the workflow in a secret
     secret = {


### PR DESCRIPTION
Updating tc-admin to 2.3.0 brings several changes: 
1. the base docker image can not be `python:3.7-slim` anymore as the update brings a new dependancy that needs gcc
2. the taskcluster client library is also updated, so we can use the helper class `TaskclusterConfig` to share authentication across services. Loading secrets is also more convenient.