### PR TITLE
Fix setup dependency versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,15 +10,17 @@ platforms = any
 
 [options]
 install_requires =
-    taskcluster~=24.3.0
+    taskcluster~=24.2.0
+    # pin aiohttp version for tc-admin because of https://github.com/pypa/pip/issues/988
+    aiohttp~=2.3.10
 packages = find:
 include_package_data = True
 zip_safe = False
-python_requires = >=3.5
+python_requires = >=3.6
 
 [options.extras_require]
 decision =
-    tc-admin==2.3.0
+    tc-admin~=2.3.0
 dev =
     pre-commit
     tox
@@ -40,14 +42,14 @@ skip_missing_interpreters = true
 [testenv]
 extras = decision
 deps =
-    pytest==5.3.5
-    pytest-responses==0.4.0
-    responses==0.10.9
+    pytest~=5.3.5
+    pytest-responses~=0.4.0
+    responses~=0.10.9
 usedevelop = true
 commands = pytest -v --cache-clear --basetemp="{envtmpdir}" {posargs}
 
 [testenv:lint]
 deps =
-    pre-commit==2.0.1
+    pre-commit~=2.0.1
 skip_install = true
 commands = pre-commit run -a


### PR DESCRIPTION
- pin `aiohttp` to the version needed by `tc-admin` (see https://github.com/pypa/pip/issues/988)
- Python 3.6 minimum (for f-strings)
- use `~=` to allow compatible updates