### PR TITLE
Use one machine per task

### DIFF
--- a/fuzzing_tc/common/pool.py
+++ b/fuzzing_tc/common/pool.py
@@ -87,7 +87,7 @@ class MachineTypes:
         """
         for name, spec in self._data[provider][architecture].items():
             if (
-                spec["cpu"] >= min_cpu
+                spec["cpu"] == min_cpu
                 and (spec["ram"] / spec["cpu"]) >= min_ram_per_cpu
             ):
                 if not metal or (metal and spec.get("metal", False)):
@@ -246,6 +246,7 @@ class PoolConfiguration:
         Returns:
             generator of machine (name, capacity): instance type name and task capacity
         """
+        yielded = False
         for machine in machine_types.filter(
             self.cloud,
             self.cpu,
@@ -255,6 +256,8 @@ class PoolConfiguration:
         ):
             cpus = machine_types.cpus(self.cloud, self.cpu, machine)
             yield (machine, cpus // self.cores_per_task)
+            yielded = True
+        assert yielded, "No available machines match specified configuration"
 
     def cycle_crons(self, start=None):
         """Generate cron patterns that correspond to cycle_time (starting from now)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -31,13 +31,13 @@ def test_parse_size(size, divisor, result):
 @pytest.mark.parametrize(
     "provider, cpu, cores, ram, metal, result",
     [
-        ("gcp", "x64", 1, 1, False, ["base", "2-cpus", "more-ram", "metal"]),
+        ("gcp", "x64", 1, 1, False, ["base", "metal"]),
         ("gcp", "x64", 2, 1, False, ["2-cpus", "more-ram"]),
         ("gcp", "x64", 2, 5, False, ["more-ram"]),
         ("gcp", "x64", 1, 1, True, ["metal"]),
-        ("aws", "arm64", 1, 1, False, ["a1", "a2", "a3"]),
-        ("aws", "arm64", 2, 1, False, ["a2", "a3"]),
-        ("aws", "arm64", 12, 32, False, ["a3"]),
+        ("aws", "arm64", 1, 1, False, ["a1"]),
+        ("aws", "arm64", 2, 1, False, ["a2"]),
+        ("aws", "arm64", 12, 32, False, []),
         ("aws", "arm64", 1, 1, True, []),
         # x64 is not present in aws
         ("aws", "x64", 1, 1, False, KeyError),
@@ -136,7 +136,7 @@ def test_aws_resources(env, mock_clouds, mock_machines):
             "scopes": [],
             "disk_size": "120g",
             "cycle_time": "12h",
-            "cores_per_task": 10,
+            "cores_per_task": 2,
             "metal": False,
             "name": "Amazing fuzzing pool",
             "tasks": 3,
@@ -160,11 +160,11 @@ def test_aws_resources(env, mock_clouds, mock_machines):
         "config": {
             "launchConfigs": [
                 {
-                    "capacityPerInstance": 2,
+                    "capacityPerInstance": 1,
                     "launchConfig": {
                         "ImageId": "ami-1234",
                         "InstanceMarketOptions": {"MarketType": "spot"},
-                        "InstanceType": "a3",
+                        "InstanceType": "a2",
                         "Placement": {"AvailabilityZone": "us-west-1a"},
                         "SecurityGroupIds": ["sg-A"],
                         "SubnetId": "subnet-XXX",


### PR DESCRIPTION
... until we can be sure multiple containers per machine will contend correctly.