### PR TITLE
Add support for blacklisting zones.

### DIFF
--- a/fuzzing_tc/decision/providers.py
+++ b/fuzzing_tc/decision/providers.py
@@ -83,10 +83,10 @@ class AWS(object):
                 },
                 "workerConfig": worker_config,
             }
-            for instance, capacity in machines
+            for instance, capacity, az_blacklist in machines
             for region_name, region in self.regions.items()
             for az, subnet in region["subnets"].items()
-            if region_name in amis
+            if region_name in amis and az not in az_blacklist
         ]
 
 
@@ -139,7 +139,8 @@ class GCP(object):
                     "shutdown": {"enabled": True, "afterIdleSeconds": 900}
                 },
             }
-            for instance, capacity in machines
+            for instance, capacity, zone_blacklist in machines
             for region, zones in self.regions.items()
             for zone in zones
+            if zone not in zone_blacklist
         ]

--- a/tests/fixtures/community/config/gcp.yml
+++ b/tests/fixtures/community/config/gcp.yml
@@ -3,4 +3,4 @@
 
 regions:
   us-west1:
-    zones: ["a"]
+    zones: ["a", "b"]

--- a/tests/fixtures/machines.yml
+++ b/tests/fixtures/machines.yml
@@ -9,6 +9,8 @@ gcp:
     more-ram:
       cpu: 2
       ram: 16
+      zone_blacklist:
+        - us-west1-b
     metal:
       cpu: 1
       ram: 1

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -274,6 +274,30 @@ def test_gcp_resources(env, mock_clouds, mock_machines):
                             "type": "PERSISTENT",
                         }
                     ],
+                    "machineType": "zones/us-west1-b/machineTypes/2-cpus",
+                    "networkInterfaces": [
+                        {"accessConfigs": [{"type": "ONE_TO_ONE_NAT"}]}
+                    ],
+                    "region": "us-west1",
+                    "scheduling": {"onHostMaintenance": "terminate"},
+                    "workerConfig": {
+                        "shutdown": {"afterIdleSeconds": 900, "enabled": True}
+                    },
+                    "zone": "us-west1-b",
+                },
+                {
+                    "capacityPerInstance": 1,
+                    "disks": [
+                        {
+                            "autoDelete": True,
+                            "boot": True,
+                            "initializeParams": {
+                                "diskSizeGb": 120,
+                                "sourceImage": "path/to/image",
+                            },
+                            "type": "PERSISTENT",
+                        }
+                    ],
                     "machineType": "zones/us-west1-a/machineTypes/more-ram",
                     "networkInterfaces": [
                         {"accessConfigs": [{"type": "ONE_TO_ONE_NAT"}]}


### PR DESCRIPTION
... since not all machine types exist in all zones.

I'm not sure if this could be better represented with wildcards, but if the file becomes too cluttered with blacklists, that can be the next step.

Fixes #55.