### PR TITLE
Preprocess must also be supported in pool-launch.

### DIFF
--- a/fuzzing_tc/decision/pool.py
+++ b/fuzzing_tc/decision/pool.py
@@ -213,6 +213,7 @@ class PoolConfiguration(CommonPoolConfiguration):
                     "env": {
                         "TASKCLUSTER_FUZZING_POOL": self.pool_id,
                         "TASKCLUSTER_SECRET": DECISION_TASK_SECRET,
+                        "TASKCLUSTER_FUZZING_PREPROCESS": "1",
                     },
                     "features": {"taskclusterProxy": True},
                     "image": preprocess.container,

--- a/fuzzing_tc/pool_launch/cli.py
+++ b/fuzzing_tc/pool_launch/cli.py
@@ -21,6 +21,12 @@ def main(args=None):
         help="The target fuzzing pool to create tasks for",
         default=os.environ.get("TASKCLUSTER_FUZZING_POOL"),
     )
+    parser.add_argument(
+        "--preprocess",
+        action="store_true",
+        help="Load the pre-process config instead of the normal pool config",
+        default=os.environ.get("TASKCLUSTER_FUZZING_PREPROCESS") == "1",
+    )
     parser.add_argument("command", help="docker command-line", nargs=argparse.REMAINDER)
     args = parser.parse_args(args=args)
 
@@ -28,7 +34,7 @@ def main(args=None):
     logging.basicConfig(level=logging.INFO)
 
     # Configure workflow using the secret or local configuration
-    launcher = PoolLauncher(args.command, args.pool_name)
+    launcher = PoolLauncher(args.command, args.pool_name, args.preprocess)
     config = launcher.configure(
         local_path=args.configuration,
         secret=args.taskcluster_secret,

--- a/fuzzing_tc/pool_launch/launcher.py
+++ b/fuzzing_tc/pool_launch/launcher.py
@@ -20,12 +20,13 @@ class PoolLauncher(Workflow):
     """Launcher for a fuzzing pool, using docker parameters from a private repo.
     """
 
-    def __init__(self, command, pool_name):
+    def __init__(self, command, pool_name, preprocess=False):
         super().__init__()
 
         self.command = command.copy()
         self.environment = os.environ.copy()
         self.pool_name = pool_name
+        self.preprocess = preprocess
         self.log_dir = pathlib.Path("/logs")
 
     def clone(self, config):
@@ -41,6 +42,9 @@ class PoolLauncher(Workflow):
 
         # Build tasks needed for a specific pool
         pool_config = PoolConfiguration.from_file(path)
+        if self.preprocess:
+            pool_config = pool_config.create_preprocess()
+            assert pool_config is not None, "preprocess given, but could not be loaded"
         pool_config.assert_complete()
 
         if pool_config.command:

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -90,6 +90,39 @@ def test_load_params(tmp_path):
     with pytest.raises(AssertionError):
         launcher.load_params()
 
+    # test 4: preprocess task is loaded
+    preproc_data = {
+        "cloud": None,
+        "scopes": [],
+        "disk_size": None,
+        "cycle_time": None,
+        "cores_per_task": None,
+        "metal": None,
+        "name": "preproc",
+        "tasks": 1,
+        "command": None,
+        "container": None,
+        "minimum_memory_per_core": None,
+        "imageset": None,
+        "parents": [],
+        "cpu": None,
+        "platform": None,
+        "preprocess": None,
+        "macros": {"PREPROC": "1"},
+    }
+    pool_data["preprocess"] = "preproc"
+    with (tmp_path / "test-pool.yml").open("w") as test_cfg:
+        yaml.dump(pool_data, stream=test_cfg)
+    with (tmp_path / "preproc.yml").open("w") as test_cfg:
+        yaml.dump(preproc_data, stream=test_cfg)
+
+    launcher = PoolLauncher([], "test-pool", True)
+    launcher.fuzzing_config_dir = tmp_path
+
+    launcher.load_params()
+    assert launcher.command == ["new-command", "arg1", "arg2"]
+    assert launcher.environment == {"STATIC": "value", "PREPROC": "1"}
+
 
 def test_launch_exec(tmp_path, monkeypatch):
     # Start with taskcluster detection disabled, even on CI

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -527,8 +527,12 @@ def test_preprocess_tasks():
         return date
 
     expected = [
-        {"name": "preprocess", "deps": ["someTaskId"]},
-        {"name": "1/1", "deps": ["someTaskId", task_ids[0]]},
+        {
+            "name": "preprocess",
+            "deps": ["someTaskId"],
+            "extra_env": {"TASKCLUSTER_FUZZING_PREPROCESS": "1"},
+        },
+        {"name": "1/1", "deps": ["someTaskId", task_ids[0]], "extra_env": {}},
     ]
     for task, expect in zip(tasks, expected):
         created = _check_date(task, "created")
@@ -539,6 +543,7 @@ def test_preprocess_tasks():
             "TASKCLUSTER_FUZZING_POOL": "pre-pool",
             "TASKCLUSTER_SECRET": "project/fuzzing/decision",
         }
+        expected_env.update(expect["extra_env"])
 
         log_expires = _check_date(
             task, "payload", "artifacts", "project/fuzzing/private/logs", "expires"


### PR DESCRIPTION
This adds an extra macro: `TASKCLUSTER_FUZZING_PREPROCESS` for the decision to communicate to pool_launch that the preprocess should be loaded and not fuzzing tasks.