### PR TITLE
Add dry-run and logging args to decision and pool-launch entrypoints

### DIFF
--- a/fuzzing_tc/common/cli.py
+++ b/fuzzing_tc/common/cli.py
@@ -5,6 +5,7 @@
 # obtain one at http://mozilla.org/MPL/2.0/.
 
 import argparse
+import logging
 import os
 import pathlib
 
@@ -32,4 +33,22 @@ def build_cli_parser(*args, **kwargs):
         help="A git revision for the fuzzing git repository",
         default=os.environ.get("FUZZING_GIT_REVISION"),
     )
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--quiet",
+        "-q",
+        dest="log_level",
+        action="store_const",
+        const=logging.WARNING,
+        help="Be less verbose",
+    )
+    group.add_argument(
+        "--verbose",
+        "-v",
+        dest="log_level",
+        action="store_const",
+        const=logging.DEBUG,
+        help="Be more verbose",
+    )
+    parser.set_defaults(log_level=logging.INFO)
     return parser

--- a/fuzzing_tc/decision/cli.py
+++ b/fuzzing_tc/decision/cli.py
@@ -23,6 +23,11 @@ def main():
         help="Taskcluster decision task creating new fuzzing tasks",
         default=os.environ.get("TASK_ID"),
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build the task group, but exit before creating tasks in Taskcluster.",
+    )
     args = parser.parse_args()
 
     # We need both task & task group information
@@ -30,7 +35,7 @@ def main():
         raise Exception("Missing decision task id")
 
     # Setup logger
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=args.log_level)
 
     # Configure workflow using the secret or local configuration
     workflow = Workflow()
@@ -45,4 +50,4 @@ def main():
     workflow.clone(config)
 
     # Build all task definitions for that pool
-    workflow.build_tasks(args.pool_name, args.task_id, config)
+    workflow.build_tasks(args.pool_name, args.task_id, config, dry_run=args.dry_run)

--- a/fuzzing_tc/decision/workflow.py
+++ b/fuzzing_tc/decision/workflow.py
@@ -142,7 +142,7 @@ class Workflow(CommonWorkflow):
             rf"Role=hook-id:{HOOK_PREFIX}/{role_suffix}",
         ]
 
-    def build_tasks(self, pool_name, task_id, config):
+    def build_tasks(self, pool_name, task_id, config, dry_run=False):
         path = self.fuzzing_config_dir / f"{pool_name}.yml"
         assert path.exists(), f"Missing pool {pool_name}"
 
@@ -156,11 +156,12 @@ class Workflow(CommonWorkflow):
         pool_config = PoolConfiguration.from_file(path)
         tasks = pool_config.build_tasks(task_id, env)
 
-        # Create all the tasks on taskcluster
-        queue = taskcluster.get_service("queue")
-        for task_id, task in tasks:
-            logger.info(f"Creating task {task['metadata']['name']} as {task_id}")
-            queue.createTask(task_id, task)
+        if not dry_run:
+            # Create all the tasks on taskcluster
+            queue = taskcluster.get_service("queue")
+            for task_id, task in tasks:
+                logger.info(f"Creating task {task['metadata']['name']} as {task_id}")
+                queue.createTask(task_id, task)
 
     def cleanup(self):
         """Cleanup temporary folders at end of execution"""

--- a/fuzzing_tc/pool_launch/cli.py
+++ b/fuzzing_tc/pool_launch/cli.py
@@ -27,11 +27,16 @@ def main(args=None):
         help="Load the pre-process config instead of the normal pool config",
         default=os.environ.get("TASKCLUSTER_FUZZING_PREPROCESS") == "1",
     )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Load the configuration, but exit before executing the command.",
+    )
     parser.add_argument("command", help="docker command-line", nargs=argparse.REMAINDER)
     args = parser.parse_args(args=args)
 
     # Setup logger
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=args.log_level)
 
     # Configure workflow using the secret or local configuration
     launcher = PoolLauncher(args.command, args.pool_name, args.preprocess)
@@ -47,5 +52,6 @@ def main(args=None):
         launcher.clone(config)
         launcher.load_params()
 
-    # Build all task definitions for that pool
-    launcher.exec()
+    if not args.dry_run:
+        # Execute command
+        launcher.exec()


### PR DESCRIPTION
`--dry-run` => for decision, don't commit to taskcluster, for pool-launch, don't execute the fuzzer.
`--verbose` => more logging
`--quiet` => less logging