### PR TITLE
Allow numeric fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ A docker image is produced and stored [as Taskcluster artifacts](https://communi
 
 ## Running in production
 
-Two modes of execution are available through the same code base (and Docker image):
+Three modes of execution are available through the same code base (and Docker image):
 
 1. Using `tc-admin` on a CI/CD git workflow of private configuration repositories, to manage resources.
 2. Using `fuzzing-decision` in a Taskcluster hook or task, to bootstrap a fuzzing workflow across several tasks in the same group.
+3. Using `fuzzing-pool-launch` as a Docker image entrypoint, which detects if it is running in a Taskcluster deployment, and if so uses the private fuzzing configuration repository to load a private command-line and environment, as well as redirect stdout/err to a private log artifact.
 
 ### Managing resources
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,13 +46,22 @@ skip_missing_interpreters = true
 extras = decision
 deps =
     pytest~=5.3.5
+    pytest-cov~=2.8.1
     pytest-responses~=0.4.0
     responses~=0.10.9
 usedevelop = true
-commands = pytest -v --log-level=DEBUG --cache-clear --basetemp="{envtmpdir}" {posargs}
+commands = pytest -v --log-level=DEBUG --cache-clear --cov="{toxinidir}" --cov-report term-missing --basetemp="{envtmpdir}" {posargs}
 
 [testenv:lint]
 deps =
     pre-commit~=2.0.1
 skip_install = true
 commands = pre-commit run -a
+
+[coverage:run]
+omit =
+    setup.py
+    tests/*
+    dist/*
+    .tox/*
+    .egg/*

--- a/tests/fixtures/pools/pool1.yml
+++ b/tests/fixtures/pools/pool1.yml
@@ -20,5 +20,5 @@ cpu: arm64
 platform: linux
 preprocess: null
 macros:
-  ENVVAR1: "123456"
+  ENVVAR1: 123456
   ENVVAR2: 789abc


### PR DESCRIPTION
A number of fields are numeric, but allow shortcuts like "1g" for 1 gigabyte, or "4h30m" instead of 16200 seconds. This allows casting any of those fields to string, if they are given numerically. This will also be useful by allowing `ENVVAR: 1` in yaml instead of requiring `ENVVAR: "1"`.

This includes a other few minor updates:
- Update README
- Fix timezone being ignored in `schedule_start`
- Add test for `schedule_start: null`
- Enable pycoverage calculation in pytest (not reported to codecov.io yet)