### PR TITLE
Add "PoolConfigMap" to support coverage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ A docker image is produced and stored [as Taskcluster artifacts](https://communi
 
 ## Running in production
 
-Two modes of execution are available through the same code base (and Docker image):
+Three modes of execution are available through the same code base (and Docker image):
 
 1. Using `tc-admin` on a CI/CD git workflow of private configuration repositories, to manage resources.
 2. Using `fuzzing-decision` in a Taskcluster hook or task, to bootstrap a fuzzing workflow across several tasks in the same group.
+3. Using `fuzzing-pool-launch` as a Docker image entrypoint, which detects if it is running in a Taskcluster deployment, and if so uses the private fuzzing configuration repository to load a private command-line and environment, as well as redirect stdout/err to a private log artifact.
 
 ### Managing resources
 

--- a/fuzzing_tc/common/pool.py
+++ b/fuzzing_tc/common/pool.py
@@ -13,7 +13,6 @@ import re
 import types
 
 import dateutil.parser
-import dateutil.tz
 import yaml
 
 LOG = logging.getLogger("fuzzing_tc.common.pool")
@@ -273,8 +272,12 @@ class CommonPoolConfiguration(abc.ABC):
         """
         if self.schedule_start is not None:
             now = self.schedule_start
-            if now.utcoffset() is not None:
-                now = now.astimezone(dateutil.tz.UTC)
+            if now.utcoffset() is None:
+                # no timezone was specified. treat it as UTC
+                now = now.replace(tzinfo=datetime.timezone.utc)
+            else:
+                # timezone was given, shift the datetime to be equivalent but in UTC
+                now = now.astimezone(datetime.timezone.utc)
         else:
             now = datetime.datetime.now(datetime.timezone.utc)
         interval = datetime.timedelta(seconds=self.cycle_time)

--- a/fuzzing_tc/decision/pool.py
+++ b/fuzzing_tc/decision/pool.py
@@ -4,10 +4,13 @@
 # v. 2.0. If a copy of the MPL was not distributed with this file, You can
 # obtain one at http://mozilla.org/MPL/2.0/.
 
+import itertools
+import logging
 import math
 from datetime import datetime
 from datetime import timedelta
 
+import yaml
 from taskcluster.utils import fromNow
 from taskcluster.utils import slugId
 from taskcluster.utils import stringDate
@@ -15,6 +18,7 @@ from tcadmin.resources import Hook
 from tcadmin.resources import Role
 from tcadmin.resources import WorkerPool
 
+from ..common.pool import PoolConfigMap as CommonPoolConfigMap
 from ..common.pool import PoolConfiguration as CommonPoolConfiguration
 from . import DECISION_TASK_SECRET
 from . import HOOK_PREFIX
@@ -23,6 +27,8 @@ from . import PROVIDER_IDS
 from . import PROVISIONER_ID
 from . import SCHEDULER_ID
 from . import WORKER_POOL_PREFIX
+
+LOG = logging.getLogger("fuzzing_tc.decision.pool")
 
 DESCRIPTION = """*DO NOT EDIT* - This resource is configured automatically.
 
@@ -52,29 +58,6 @@ def add_capabilities_for_scopes(task):
 
 
 class PoolConfiguration(CommonPoolConfiguration):
-    """Fuzzing Pool Configuration
-
-    Attributes:
-        cloud (str): cloud provider, like aws or gcp
-        command (list): list of strings, command to execute in the image/container
-        container (str): name of the container
-        cores_per_task (int): number of cores to be allocated per task
-        cpu (int): cpu architecture (eg. x64/arm64)
-        cycle_time (int): maximum run time of this pool in seconds
-        disk_size (int): disk size in GB
-        imageset (str): imageset name in community-tc-config/config/imagesets.yml
-        macros (dict): dictionary of environment variables passed to the target
-        metal (bool): whether or not the target requires to be run on bare metal
-        minimum_memory_per_core (float): minimum RAM to be made available per core in GB
-        name (str): descriptive name of the configuration
-        parents (list): list of parents to inherit from
-        platform (str): operating system of the target (linux, windows)
-        pool_id (str): basename of the pool on disk (eg. "pool1" for pool1.yml)
-        scopes (list): list of taskcluster scopes required by the target
-        task_id (str): ID to use to refer to the task in Taskcluster
-        tasks (int): number of tasks to run (each with `cores_per_task`)
-    """
-
     @property
     def task_id(self):
         return f"{self.platform}-{self.pool_id}"
@@ -289,3 +272,188 @@ class PoolConfiguration(CommonPoolConfiguration):
                 task["payload"]["env"].update(env)
 
             yield task_id, task
+
+
+class PoolConfigMap(CommonPoolConfigMap):
+    RESULT_TYPE = PoolConfiguration
+
+    @property
+    def task_id(self):
+        return f"{self.platform}-{self.pool_id}"
+
+    def build_resources(self, providers, machine_types, env=None):
+        """Build the full tc-admin resources to compare and build the pool"""
+
+        # Select a cloud provider according to configuration
+        assert self.cloud in providers, f"Cloud Provider {self.cloud} not available"
+        provider = providers[self.cloud]
+
+        pools = list(self.iterpools())
+        all_scopes = tuple(
+            set(itertools.chain.from_iterable(pool.scopes for pool in pools))
+        )
+
+        # Build the pool configuration for selected machines
+        machines = self.get_machine_list(machine_types)
+        config = {
+            "minCapacity": 0,
+            "maxCapacity": sum(pool.tasks for pool in pools) + 1,
+            "launchConfigs": provider.build_launch_configs(
+                self.imageset, machines, self.disk_size
+            ),
+            "lifecycle": {
+                # give workers 15 minutes to register before assuming they're broken
+                "registrationTimeout": 900,
+            },
+        }
+
+        # Mandatory scopes to execute the hook
+        # or create new tasks
+        decision_task_scopes = (
+            f"queue:scheduler-id:{SCHEDULER_ID}",
+            f"queue:create-task:highest:{PROVISIONER_ID}/{self.task_id}",
+            f"secrets:get:{DECISION_TASK_SECRET}",
+        )
+
+        # Build the decision task payload that will trigger the new fuzzing tasks
+        decision_task = {
+            "created": {"$fromNow": "0 seconds"},
+            "deadline": {"$fromNow": "1 hour"},
+            "expires": {"$fromNow": "1 week"},
+            "extra": {},
+            "metadata": {
+                "description": DESCRIPTION,
+                "name": f"Fuzzing decision {self.task_id}",
+                "owner": OWNER_EMAIL,
+                "source": "https://github.com/MozillaSecurity/fuzzing-tc",
+            },
+            "payload": {
+                "artifacts": {},
+                "cache": {},
+                "capabilities": {},
+                "env": {"TASKCLUSTER_SECRET": DECISION_TASK_SECRET},
+                "features": {"taskclusterProxy": True},
+                "image": {
+                    "type": "indexed-image",
+                    "path": "public/fuzzing-tc-decision.tar",
+                    "namespace": "project.fuzzing.config.master",
+                },
+                "command": ["fuzzing-decision", self.pool_id],
+                "maxRunTime": 3600,
+            },
+            "priority": "high",
+            "provisionerId": PROVISIONER_ID,
+            "workerType": self.task_id,
+            "retries": 3,
+            "routes": [],
+            "schedulerId": SCHEDULER_ID,
+            "scopes": all_scopes + decision_task_scopes,
+            "tags": {},
+        }
+        add_capabilities_for_scopes(decision_task)
+        if env is not None:
+            assert set(decision_task["payload"]["env"].keys()).isdisjoint(
+                set(env.keys())
+            )
+            decision_task["payload"]["env"].update(env)
+
+        pool = WorkerPool(
+            workerPoolId=f"{WORKER_POOL_PREFIX}/{self.task_id}",
+            providerId=PROVIDER_IDS[self.cloud],
+            description=DESCRIPTION,
+            owner=OWNER_EMAIL,
+            emailOnError=True,
+            config=config,
+        )
+
+        hook = Hook(
+            hookGroupId=HOOK_PREFIX,
+            hookId=self.task_id,
+            name=self.task_id,
+            description="Generated Fuzzing hook",
+            owner=OWNER_EMAIL,
+            emailOnError=True,
+            schedule=list(self.cycle_crons()),
+            task=decision_task,
+            bindings=(),
+            triggerSchema={},
+        )
+
+        role = Role(
+            roleId=f"hook-id:{HOOK_PREFIX}/{self.task_id}",
+            description=DESCRIPTION,
+            scopes=all_scopes + decision_task_scopes,
+        )
+
+        return [pool, hook, role]
+
+    def build_tasks(self, parent_task_id, env=None):
+        """Create fuzzing tasks and attach them to a decision task"""
+        now = datetime.utcnow()
+        deps = [parent_task_id]
+
+        for pool in self.iterpools():
+            for i in range(1, pool.tasks + 1):
+                task_id = slugId()
+                task = {
+                    "taskGroupId": parent_task_id,
+                    "dependencies": deps,
+                    "created": stringDate(now),
+                    "deadline": stringDate(now + timedelta(seconds=pool.max_run_time)),
+                    "expires": stringDate(fromNow("1 week", now)),
+                    "extra": {},
+                    "metadata": {
+                        "description": DESCRIPTION,
+                        "name": f"Fuzzing task {pool.platform}-{pool.pool_id} - {i}/{pool.tasks}",
+                        "owner": OWNER_EMAIL,
+                        "source": "https://github.com/MozillaSecurity/fuzzing-tc",
+                    },
+                    "payload": {
+                        "artifacts": {
+                            "project/fuzzing/private/logs": {
+                                "expires": stringDate(fromNow("1 week", now)),
+                                "path": "/logs/",
+                                "type": "directory",
+                            }
+                        },
+                        "cache": {},
+                        "capabilities": {},
+                        "env": {
+                            "TASKCLUSTER_FUZZING_POOL": pool.pool_id,
+                            "TASKCLUSTER_SECRET": DECISION_TASK_SECRET,
+                        },
+                        "features": {"taskclusterProxy": True},
+                        "image": pool.container,
+                        "maxRunTime": pool.max_run_time,
+                    },
+                    "priority": "high",
+                    "provisionerId": PROVISIONER_ID,
+                    "workerType": self.task_id,
+                    "retries": 1,
+                    "routes": [],
+                    "schedulerId": SCHEDULER_ID,
+                    "scopes": pool.scopes + [f"secrets:get:{DECISION_TASK_SECRET}"],
+                    "tags": {},
+                }
+                add_capabilities_for_scopes(task)
+                if env is not None:
+                    assert set(task["payload"]["env"]).isdisjoint(set(env))
+                    task["payload"]["env"].update(env)
+
+                yield task_id, task
+
+
+class PoolConfigLoader:
+    @staticmethod
+    def from_file(pool_yml):
+        assert pool_yml.is_file()
+        data = yaml.safe_load(pool_yml.read_text())
+        for cls in (PoolConfiguration, PoolConfigMap):
+            if set(cls.FIELD_TYPES) >= set(data.keys()) >= cls.REQUIRED_FIELDS:
+                return cls(pool_yml.stem, data, base_dir=pool_yml.parent)
+        LOG.error(
+            f"{pool_yml} has keys {data.keys()} and expected all of either "
+            f"{PoolConfiguration.REQUIRED_FIELDS} or {PoolConfigMap.REQUIRED_FIELDS} to "
+            f"exist."
+        )
+        raise RuntimeError(f"{pool_yml} type could not be identified!")

--- a/fuzzing_tc/decision/workflow.py
+++ b/fuzzing_tc/decision/workflow.py
@@ -18,7 +18,7 @@ from ..common.pool import MachineTypes
 from ..common.workflow import Workflow as CommonWorkflow
 from . import HOOK_PREFIX
 from . import WORKER_POOL_PREFIX
-from .pool import PoolConfiguration
+from .pool import PoolConfigLoader
 from .providers import AWS
 from .providers import GCP
 
@@ -98,7 +98,7 @@ class Workflow(CommonWorkflow):
 
         # Browse the files in the repo
         for config_file in self.fuzzing_config_dir.glob("pool*.yml"):
-            pool_config = PoolConfiguration.from_file(config_file)
+            pool_config = PoolConfigLoader.from_file(config_file)
             resources.update(pool_config.build_resources(clouds, machines, env))
 
     def build_resources_patterns(self):
@@ -153,7 +153,7 @@ class Workflow(CommonWorkflow):
             env["FUZZING_GIT_REVISION"] = config["fuzzing_config"]["revision"]
 
         # Build tasks needed for a specific pool
-        pool_config = PoolConfiguration.from_file(path)
+        pool_config = PoolConfigLoader.from_file(path)
         tasks = pool_config.build_tasks(task_id, env)
 
         if not dry_run:

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,13 +46,22 @@ skip_missing_interpreters = true
 extras = decision
 deps =
     pytest~=5.3.5
+    pytest-cov~=2.8.1
     pytest-responses~=0.4.0
     responses~=0.10.9
 usedevelop = true
-commands = pytest -v --log-level=DEBUG --cache-clear --basetemp="{envtmpdir}" {posargs}
+commands = pytest -v --log-level=DEBUG --cache-clear --cov="{toxinidir}" --cov-report term-missing --basetemp="{envtmpdir}" {posargs}
 
 [testenv:lint]
 deps =
     pre-commit~=2.0.1
 skip_install = true
 commands = pre-commit run -a
+
+[coverage:run]
+omit =
+    setup.py
+    tests/*
+    dist/*
+    .tox/*
+    .egg/*

--- a/tests/fixtures/pools/load-cfg.yml
+++ b/tests/fixtures/pools/load-cfg.yml
@@ -1,0 +1,14 @@
+name: test
+parents: []
+metal: False
+cores_per_task: 1
+imageset: test
+tasks: 1
+max_run_time: 1s
+disk_size: 1b
+minimum_memory_per_core: 1b
+cycle_time: 1s
+cloud: gcp
+cpu: x64
+container: test
+platform: test

--- a/tests/fixtures/pools/load-map.yml
+++ b/tests/fixtures/pools/load-map.yml
@@ -1,0 +1,3 @@
+name: test
+apply_to:
+  - load-cfg

--- a/tests/fixtures/pools/map1.yml
+++ b/tests/fixtures/pools/map1.yml
@@ -1,0 +1,3 @@
+name: mixed
+apply_to:
+  - pool1

--- a/tests/fixtures/pools/pool1.yml
+++ b/tests/fixtures/pools/pool1.yml
@@ -20,5 +20,5 @@ cpu: arm64
 platform: linux
 preprocess: null
 macros:
-  ENVVAR1: "123456"
+  ENVVAR1: 123456
   ENVVAR2: 789abc

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import copy
-from datetime import datetime
-from datetime import timedelta
+import datetime
 from pathlib import Path
 
 import pytest
 import slugid
-from dateutil.tz import UTC
 
 from fuzzing_tc.common.pool import PoolConfigLoader as CommonPoolConfigLoader
 from fuzzing_tc.common.pool import PoolConfigMap as CommonPoolConfigMap
@@ -445,7 +443,7 @@ def test_tasks(env, scope_caps):
             assert isinstance(obj, dict)
             value = obj[key]
         assert isinstance(value, str)
-        date = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+        date = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
         del obj[key]
         return date
 
@@ -531,7 +529,7 @@ def test_preprocess_tasks():
             assert isinstance(obj, dict)
             value = obj[key]
         assert isinstance(value, str)
-        date = datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
+        date = datetime.datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%fZ")
         del obj[key]
         return date
 
@@ -763,11 +761,11 @@ def test_cycle_crons():
     # using schedule_start should be the same as using datetime.now()
     conf.schedule_start = None
     conf.cycle_time = 3600 * 12
-    start = datetime.now(UTC)
+    start = datetime.datetime.now(datetime.timezone.utc)
     calc_none = list(conf.cycle_crons())
-    fin = datetime.now(UTC)
+    fin = datetime.datetime.now(datetime.timezone.utc)
     for offset in range(int((fin - start).total_seconds()) + 1):
-        conf.schedule_start = start + timedelta(seconds=offset)
+        conf.schedule_start = start + datetime.timedelta(seconds=offset)
         if calc_none == list(conf.cycle_crons()):
             break
     else:


### PR DESCRIPTION
Note: The first two commits in this PR are submitted separately as #73.

This is a config that works like a map function, applying itself to each config defined in `apply_to`. Any field can be overwritten, but some fields must be consistent across the entire result:

- `cloud`
- `cores_per_task`
- `cpu`
- `cycle_time`
- `disk_size`
- `imageset`
- `metal`
- `minimum_memory_per_core`
- `platform`
- `schedule_start`

Some of these are required to keep scheduling sane. The others are limitations of the current strategy of using one 1:1 TC WorkerPools to fuzzing Pools. This would be fixed by #62.

Also, `preprocess` fields are not supported (must be blank if used by any config in `apply_to`).

Fixes #45.